### PR TITLE
Additional work on bundling

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -228,10 +228,16 @@ function reloadOptions() {
 		document.body.classList.remove(AVATAR_OPTION_CLASS);
 	}
 	
+	// Add option classes to body for css styling, and unbundle emails when disabled
 	if (options.emailBundling === 'enabled' && !document.body.classList.contains(BUNDLING_OPTION_CLASS)) {
 		document.body.classList.add(BUNDLING_OPTION_CLASS);
 	} else if (options.emailBundling === 'disabled' && document.body.classList.contains(BUNDLING_OPTION_CLASS)) {
 		document.body.classList.remove(BUNDLING_OPTION_CLASS);
+		
+		// Unbundle emails
+		document.querySelectorAll('.' + BUNDLED_EMAIL_CLASS).forEach(x => x.classList.remove(BUNDLED_EMAIL_CLASS));
+		// Remove bundle elements
+		document.querySelectorAll('.' + BUNDLE_WRAPPER_CLASS).forEach(x => x.remove());
 	}
 }
 

--- a/src/script.js
+++ b/src/script.js
@@ -229,7 +229,7 @@ function reloadOptions() {
 }
 
 const getLabels = function(email) {
-	return Array.from(email.querySelectorAll(".ar")).map(el => el.innerText);
+	return Array.from(email.querySelectorAll('.ar .at')).map(el => el.attributes.title.value);
 };
 
 const htmlToElements = function(html) {

--- a/src/script.js
+++ b/src/script.js
@@ -149,14 +149,23 @@ const buildDateLabel = function(date) {
 	return date.getFullYear().toString();
 };
 
-const cleanupDateLabels =  function() {
+const cleanupDateLabels = function() {
     document.querySelectorAll(".time-row").forEach(row => {
-    	// delete any back to back date labels
-    	if(row.nextSibling && row.nextSibling.className === "time-row") {
-    		row.remove();
-		}
-	});
+    	// Delete any back to back date labels
+    	if (row.nextSibling && row.nextSibling.className === 'time-row') row.remove();
+
+			// TODO: check nextSibling recursively until reaching the next .time-row
+			// if all siblings are .bundled-email, then row.remove()
+			if (isEmptyDateLabel(row)) row.remove();
+		});
 };
+
+const isEmptyDateLabel = function (row) {
+	const sibling = row.nextSibling;
+	if (sibling.className === 'time-row') return true;
+	else if (sibling.classList.contains('.bundled-email')) return false;
+	return isEmptyDateLabel(sibling);
+}
 
 const getBundledLabels = function() {
 	return Array.from(document.querySelectorAll(".BltHke[role=main] .bundle-wrapper .label-link")).reduce((acc, e) => {acc[e.innerText] = true; return acc;}, {});

--- a/src/script.js
+++ b/src/script.js
@@ -252,7 +252,7 @@ const buildBundleWrapper = function(email, label, hasImportantMarkers) {
 	addClassToEmail(bundleWrapper, BUNDLE_WRAPPER_CLASS);
 
 	bundleWrapper.onclick = () => {
-		location.href = `#search/in%3Ainbox+label%3A"${fixLabel(label.toLowerCase())}"`;
+		location.href = `#search/in%3Ainbox+label%3A"${fixLabel(label)}"`;
 	};
 
 	if (email && email.parentNode) email.parentElement.insertBefore(bundleWrapper, email);

--- a/src/script.js
+++ b/src/script.js
@@ -258,13 +258,15 @@ const removeClassFromBundle = (label, klass) => {
 const addCountToBundle = (label, count) => {
 	const bundleLabel = document.querySelector(`div[bundleLabel="${label}"] .label-link`);
 	if (!bundleLabel) return;
-	bundleLabel.innerHTML = `<span>${label}</span><span class="bundle-count">(${count})</span>`;
+	const replacementHTML = `<span>${label}</span><span class="bundle-count">(${count})</span>`;
+	if (bundleLabel.innerHTML !== replacementHTML) bundleLabel.innerHTML = replacementHTML;
 };
 
 const addSendersToBundle = (label, senders) => {
 	const bundleSenders = document.querySelector(`div[bundleLabel="${label}"] .bundle-senders`);
 	if (!bundleSenders) return;
-	bundleSenders.innerHTML = `${senders.reverse().map(sender => `<span class="${sender.isUnread ? 'strong' : ''}">${sender.name}</span>`).join(', ')}`;
+	const replacementHTML = `${senders.reverse().map(sender => `<span class="${sender.isUnread ? 'strong' : ''}">${sender.name}</span>`).join(', ')}`
+	if (bundleSenders.innerHTML !== replacementHTML) bundleSenders.innerHTML = replacementHTML;
 };
 
 const buildBundleWrapper = function (email, label, hasImportantMarkers) {

--- a/src/script.js
+++ b/src/script.js
@@ -301,6 +301,7 @@ function getEmails() {
 		info.date = getDate(info.dateString);
 		info.dateLabel = buildDateLabel(info.date);
 		info.isSnooze = isSnoozed(email, info.date, prevTimeStamp);
+		info.isStarred = isStarred(email);
 		// Only update prevTimeStamp if not snoozed, because we might have multiple snoozes back to back
 		if (!info.isSnooze && info.date) prevTimeStamp = info.date;
 		info.isCalendarEvent = isCalendarEvent(email);
@@ -436,6 +437,7 @@ const updateReminders = function () {
 				emailEl.remove();
 				continue;
 			}
+			if (emailInfo.isStarred) continue;
 
 			const labels = emailInfo.labels;
 			if (isInInboxFlag && labels.length && !emailInfo.isUnbundled && !emailInfo.bundleAlreadyProcessed()) {
@@ -471,6 +473,10 @@ const isSnoozed = function (email, curDate, prevDate) {
 	return prevDate !== null && curDate < prevDate;
 };
 
+const isStarred = function (email) {
+	const node = email.querySelector('.T-KT');
+	if (node && node.title !== 'Not starred') return true;
+};
 
 /*
 **
@@ -525,7 +531,7 @@ const reorderMenuItems = () => {
     const refer = document.querySelector('.wT .byl>.TK');
     const { inbox, snoozed, done, drafts, sent, spam, trash, starred, important, chats } = _nodes;
 
-    if ( parent && refer && loadedMenu && inbox && snoozed && done && drafts && sent && spam && trash && starred && important && chats) {
+    if (parent && refer && loadedMenu && inbox && snoozed && done && drafts && sent && spam && trash && starred && important && chats) {
       // Gmail will execute its script to add element to the first child, so
       // add one placeholder for it and do the rest in the next child.
       const placeholder = document.createElement('div');
@@ -558,10 +564,7 @@ const reorderMenuItems = () => {
       parent.insertBefore(placeholder, refer);
       parent.insertBefore(newNode, refer);
 
-      setupClickEventForNodes([
-        inbox, snoozed, done, drafts, sent,
-        spam, trash, starred, important, chats,
-      ]);
+      setupClickEventForNodes([inbox, snoozed, done, drafts, sent, spam, trash, starred, important, chats]);
 
       // Close More menu
       document.body.querySelector('.J-Ke.n4.ah9').click();

--- a/src/script.js
+++ b/src/script.js
@@ -251,17 +251,17 @@ const buildBundleWrapper = function(email, label, hasImportantMarkers) {
 	const importantMarkerClass = hasImportantMarkers ? "" : "hide-important-markers";
 
 	const bundleWrapper = htmlToElements(
-			`<div class=\"zA yO\" bundleLabel=\"${label}\">` +
-			"	<span class=\"oZ-x3 xY aid bundle-image\"><img src=\"https://i.ibb.co/wCh8tQ9/ic-custom-cluster-24px-g60-r3-2x.png\" /></span>" +
-			`	<span class='WA xY ${importantMarkerClass}'></span>` +
-			`	<span class=\"yX xY label-link .yW\">${label}</span>` +
-			`	<span class=\"xW xY \"><span title=\"${getRawDate(email)}\"></span></span>` +
+			`<div class="zA yO" bundleLabel="${label}">` +
+			`	<span class="oZ-x3 xY aid bundle-image"><img src="${chrome.runtime.getURL('images/ic_custom-cluster_24px_g60_r3_2x.png')}" /></span>` +
+			`	<span class="WA xY ${importantMarkerClass}"></span>` +
+			`	<span class="yX xY label-link .yW">${label}</span>` +
+			`	<span class="xW xY"><span title="${getRawDate(email)}"></span></span>` +
 			"</div>");
 
 	addClassToEmail(bundleWrapper, BUNDLE_WRAPPER_CLASS);
 
 	bundleWrapper.onclick = () => {
-		location.href = "#search/in%3Ainbox+label%3A\"" + fixLabel(label.toLowerCase()) + "\"";
+		location.href = `#search/in%3Ainbox+label%3A"${fixLabel(label.toLowerCase())}"`;
 	};
 
 	if(email && email.parentNode) {

--- a/src/script.js
+++ b/src/script.js
@@ -136,19 +136,19 @@ const buildDateLabel = function(date) {
 };
 
 const cleanupDateLabels = function() {
-    document.querySelectorAll(".time-row").forEach(row => {
-    	// Delete any back to back date labels
-    	if (row.nextSibling && row.nextSibling.className === 'time-row') row.remove();
-
-			// Check nextSibling recursively until reaching the next .time-row
-			// If all siblings are .bundled-email, then hide row
-			if (isEmptyDateLabel(row)) row.hidden = true;
-		});
+	document.querySelectorAll(".time-row").forEach(row => {
+		// Delete any back to back date labels
+		if (row.nextSibling && row.nextSibling.className === 'time-row') row.remove();
+		// Check nextSibling recursively until reaching the next .time-row
+		// If all siblings are .bundled-email, then hide row
+		else if (isEmptyDateLabel(row)) row.hidden = true;
+	});
 };
 
 const isEmptyDateLabel = function (row) {
 	const sibling = row.nextSibling;
-	if (sibling.className === 'time-row') return true;
+	if (!sibling) return true;
+	else if (sibling.className === 'time-row') return true;
 	else if (![...sibling.classList].includes('bundled-email')) return false;
 	return isEmptyDateLabel(sibling);
 }

--- a/src/script.js
+++ b/src/script.js
@@ -265,7 +265,8 @@ const addCountToBundle = (label, count) => {
 const addSendersToBundle = (label, senders) => {
 	const bundleSenders = document.querySelector(`div[bundleLabel="${label}"] .bundle-senders`);
 	if (!bundleSenders) return;
-	const replacementHTML = `${senders.reverse().map(sender => `<span class="${sender.isUnread ? 'strong' : ''}">${sender.name}</span>`).join(', ')}`
+	let uniqueSenders = senders.reverse().filter((sender, index, self) => self.findIndex(s => s.name === sender.name && s.isUnread === sender.isUnread) === index);
+	const replacementHTML = `${uniqueSenders.map(sender => `<span class="${sender.isUnread ? 'strong' : ''}">${sender.name}</span>`).join(', ')}`
 	if (bundleSenders.innerHTML !== replacementHTML) bundleSenders.innerHTML = replacementHTML;
 };
 
@@ -392,10 +393,20 @@ const getEmails = () => {
 			const firstParticipant = participants[0].getAttribute('name');
 			info.labels.forEach(label => {
 				if (!(label in labelStats)) {
-					labelStats[label] = { title: label, count: 1, senders: [{ name: firstParticipant, isUnread: info.isUnread }] };
+					labelStats[label] = {
+						title: label,
+						count: 1,
+						senders: [{
+							name: firstParticipant,
+							isUnread: info.isUnread
+						}]
+					};
 				} else { 
 					labelStats[label].count++;
-					labelStats[label].senders.push({ name: firstParticipant, isUnread: info.isUnread })
+					labelStats[label].senders.push({
+						name: firstParticipant,
+						isUnread: info.isUnread
+					});
 				}
 				if (info.isUnread) labelStats[label].containsUnread = true;
 			});

--- a/src/script.js
+++ b/src/script.js
@@ -136,7 +136,7 @@ const buildDateLabel = function(date) {
 };
 
 const cleanupDateLabels = function() {
-	document.querySelectorAll(".time-row").forEach(row => {
+	document.querySelectorAll('.time-row').forEach(row => {
 		// Delete any back to back date labels
 		if (row.nextSibling && row.nextSibling.className === 'time-row') row.remove();
 		// Check nextSibling recursively until reaching the next .time-row

--- a/src/script.js
+++ b/src/script.js
@@ -1,5 +1,5 @@
-const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
-const days = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
 const emailRegex = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
@@ -26,34 +26,34 @@ const DATE_LABELS = {
 };
 let options = {};
 
-const nameColors = ["1bbc9b","16a086","f1c40f","f39c11","2dcc70","27ae61","d93939","d25400","3598db","297fb8","e84c3d","c1392b","9a59b5","8d44ad","bec3c7","34495e","2d3e50","95a5a4","7e8e8e","ec87bf","d870ad","f69785","9ba37e","b49255","b49255","a94136"];
+const nameColors = ['1bbc9b','16a086','f1c40f','f39c11','2dcc70','27ae61','d93939','d25400','3598db','297fb8','e84c3d','c1392b','9a59b5','8d44ad','bec3c7','34495e','2d3e50','95a5a4','7e8e8e','ec87bf','d870ad','f69785','9ba37e','b49255','b49255','a94136'];
 
 /* remove element */
-Element.prototype.remove = function() {
+Element.prototype.remove = function () {
 	this.parentElement.removeChild(this);
 };
 
 const getMyEmailAddress = function () {
-	const accountInfo = document.querySelector("div[aria-label='Account Information']");
+	const accountInfo = document.querySelector('div[aria-label="Account Information"]');
 	if (accountInfo) {
-		for (const child of accountInfo.getElementsByTagName("*")) {
+		for (const child of accountInfo.getElementsByTagName('*')) {
 			if (child.children.length > 0) continue;
-			const emailMatch = (child.innerText || "").match(emailRegex);
+			const emailMatch = (child.innerText || '').match(emailRegex);
 			if (emailMatch) return emailMatch[0];
 		}
 	}
 
-	return "";
+	return '';
 };
 
 const triggerMouseEvent = function (node, event) {
-	const mouseUpEvent = document.createEvent("MouseEvents");
+	const mouseUpEvent = document.createEvent('MouseEvents');
 	mouseUpEvent.initEvent(event, true, true);
 	node.dispatchEvent(mouseUpEvent);
 };
 
 const waitForElement = function (selector, callback, tries) {
-	if (typeof tries == "undefined") tries = 100;
+	if (typeof tries == 'undefined') tries = 100;
 
 	const element = document.querySelector(selector);
 	if (element) {
@@ -64,12 +64,12 @@ const waitForElement = function (selector, callback, tries) {
 };
 
 const getEmailParticipants = function (email) {
-	return email.querySelectorAll(".yW span[email]");
+	return email.querySelectorAll('.yW span[email]');
 };
 
-const isReminder = function(email, myEmailAddress) {
+const isReminder = function (email, myEmailAddress) {
 	// if user doesn't want reminders treated special, then just return as though current email is not a reminder
-	if (options.reminderTreatment === "none") return false;
+	if (options.reminderTreatment === 'none') return false;
 
 	const nameNodes = getEmailParticipants(email);
 	let allNamesMe = true;
@@ -77,50 +77,50 @@ const isReminder = function(email, myEmailAddress) {
 	if (nameNodes.length === 0) allNamesMe = false;
 
 	for (const nameNode of nameNodes) {
-		if (nameNode.getAttribute("email") !== myEmailAddress) allNamesMe = false;
+		if (nameNode.getAttribute('email') !== myEmailAddress) allNamesMe = false;
 	}
 
-	if (options.reminderTreatment === "all") {
+	if (options.reminderTreatment === 'all') {
 		return allNamesMe;
-	} else if (options.reminderTreatment === "containing-word") {
-		const titleNode = email.querySelector(".y6");
+	} else if (options.reminderTreatment === 'containing-word') {
+		const titleNode = email.querySelector('.y6');
 		return allNamesMe && titleNode && titleNode.innerText.match(/reminder/i);
 	}
 
 	return false;
 };
 
-const isCalendarEvent = function(email) {
-	const node = email.querySelector(".aKS .aJ6");
-	return node && node.innerText === "RSVP";
+const isCalendarEvent = function (email) {
+	const node = email.querySelector('.aKS .aJ6');
+	return node && node.innerText === 'RSVP';
 };
 
 const addDateLabel = function (email, label) {
-	if (email.previousSibling && email.previousSibling.className === "time-row") {
+	if (email.previousSibling && email.previousSibling.className === 'time-row') {
 		if (email.previousSibling.innerText === label) return;
 		email.previousSibling.remove();
 	}
 
-	const timeRow = document.createElement("div");
-	timeRow.classList.add("time-row");
-	const time = document.createElement("div");
-	time.className = "time";
+	const timeRow = document.createElement('div');
+	timeRow.classList.add('time-row');
+	const time = document.createElement('div');
+	time.className = 'time';
 	time.innerText = label;
 	timeRow.appendChild(time);
 
 	email.parentElement.insertBefore(timeRow, email);
 };
 
-const getRawDate = function(email) {
-	const dateElement = email.querySelector(".xW.xY span");
-	if (dateElement) return dateElement.getAttribute("title");
+const getRawDate = function (email) {
+	const dateElement = email.querySelector('.xW.xY span');
+	if (dateElement) return dateElement.getAttribute('title');
 };
 
-const getDate = function(rawDate) {
+const getDate = function (rawDate) {
 	if (rawDate) return new Date(rawDate);
 };
 
-const buildDateLabel = function(date) {
+const buildDateLabel = function (date) {
 	let now = new Date();
 	if (date === undefined) return;
 
@@ -137,7 +137,7 @@ const buildDateLabel = function(date) {
 	return date.getFullYear().toString();
 };
 
-const cleanupDateLabels = function() {
+const cleanupDateLabels = function () {
 	document.querySelectorAll('.time-row').forEach(row => {
 		// Delete any back to back date labels
 		if (row.nextSibling && row.nextSibling.className === 'time-row') row.remove();
@@ -155,11 +155,11 @@ const isEmptyDateLabel = function (row) {
 	return isEmptyDateLabel(sibling);
 }
 
-const getBundledLabels = function() {
+const getBundledLabels = function () {
 	return Array.from(document.querySelectorAll('.BltHke[role=main] .bundle-wrapper .label-link')).reduce((acc, e) => { acc[e.innerText] = true; return acc; }, {});
 };
 
-const addEventAttachment = function(email) {
+const addEventAttachment = function (email) {
 	if (email.querySelector('.' + CALENDAR_ATTACHMENT_CLASS)) return;
 
 	let title = 'Calendar Event';
@@ -176,48 +176,48 @@ const addEventAttachment = function(email) {
 
 	// build calendar attachment, this is based on regular attachments we no longer
 	// have access to inbox to see the full structure
-	const span = document.createElement("span");
-	span.appendChild(document.createTextNode("Attachment"));
-	span.classList.add("bzB");
+	const span = document.createElement('span');
+	span.appendChild(document.createTextNode('Attachment'));
+	span.classList.add('bzB');
 
-	const attachmentNameSpan = document.createElement("span");
-	attachmentNameSpan.classList.add("event-title");
+	const attachmentNameSpan = document.createElement('span');
+	attachmentNameSpan.classList.add('event-title');
 	attachmentNameSpan.appendChild(document.createTextNode(title));
 
-	const attachmentTimeSpan = document.createElement("span");
-	attachmentTimeSpan.classList.add("event-time");
+	const attachmentTimeSpan = document.createElement('span');
+	attachmentTimeSpan.classList.add('event-time');
 	attachmentTimeSpan.appendChild(document.createTextNode(time));
 
-	const attachmentContentWrapper = document.createElement("span");
-	attachmentContentWrapper.classList.add("brg");
+	const attachmentContentWrapper = document.createElement('span');
+	attachmentContentWrapper.classList.add('brg');
 	attachmentContentWrapper.appendChild(attachmentNameSpan);
 	attachmentContentWrapper.appendChild(attachmentTimeSpan);
 
 	// Find Invitation Action
-	const action = email.querySelector(".aKS");
+	const action = email.querySelector('.aKS');
 	if (action) attachmentContentWrapper.appendChild(action);
 
-	const imageSpan = document.createElement("span");
-	imageSpan.classList.add("calendar-image");
+	const imageSpan = document.createElement('span');
+	imageSpan.classList.add('calendar-image');
 
-	const attachmentCard = document.createElement("div");
-	attachmentCard.classList.add("brc");
-	attachmentCard.setAttribute("role", "listitem");
-	attachmentCard.setAttribute("title", title);
+	const attachmentCard = document.createElement('div');
+	attachmentCard.classList.add('brc');
+	attachmentCard.setAttribute('role', 'listitem');
+	attachmentCard.setAttribute('title', title);
 	attachmentCard.appendChild(imageSpan);
 	attachmentCard.appendChild(attachmentContentWrapper);
 
 	const attachmentNode = document.createElement('div');
-	attachmentNode.classList.add("brd", CALENDAR_ATTACHMENT_CLASS);
+	attachmentNode.classList.add('brd', CALENDAR_ATTACHMENT_CLASS);
 	attachmentNode.appendChild(span);
 	attachmentNode.appendChild(attachmentCard);
 
-	const emailSubjectWrapper = email.querySelectorAll(".a4W");
+	const emailSubjectWrapper = email.querySelectorAll('.a4W');
 	if (emailSubjectWrapper) emailSubjectWrapper[0].appendChild(attachmentNode);
 };
 
 function reloadOptions() {
-	chrome.runtime.sendMessage({ method: 'getOptions' }, function(ops) {
+	chrome.runtime.sendMessage({ method: 'getOptions' }, function (ops) {
 		options = ops;
 	});
 
@@ -226,6 +226,7 @@ function reloadOptions() {
 		document.body.classList.add(AVATAR_OPTION_CLASS);
 	} else if (options.showAvatar === 'disabled' && document.body.classList.contains(AVATAR_OPTION_CLASS)) {
 		document.body.classList.remove(AVATAR_OPTION_CLASS);
+		document.querySelectorAll('.' + AVATAR_EMAIL_CLASS).forEach(avatarEl => avatarEl.classList.remove(AVATAR_EMAIL_CLASS));
 		document.querySelectorAll('.' + AVATAR_CLASS).forEach(avatarEl => avatarEl.remove());
 	}
 	
@@ -242,26 +243,27 @@ function reloadOptions() {
 	}
 }
 
-const getLabels = function(email) {
+const getLabels = function (email) {
 	return Array.from(email.querySelectorAll('.ar .at')).map(el => el.attributes.title.value);
 };
 
-const htmlToElements = function(html) {
+const htmlToElements = function (html) {
 	var template = document.createElement('template');
 	template.innerHTML = html;
 	return template.content.firstElementChild;
 };
 
-const buildBundleWrapper = function(email, label, hasImportantMarkers) {
+const buildBundleWrapper = function (email, label, hasImportantMarkers) {
 	const importantMarkerClass = hasImportantMarkers ? '' : 'hide-important-markers';
 
-	const bundleWrapper = htmlToElements(
-			`<div class="zA yO" bundleLabel="${label}">` +
-			`	<span class="oZ-x3 xY aid bundle-image"><img src="${chrome.runtime.getURL('images/ic_custom-cluster_24px_g60_r3_2x.png')}" /></span>` +
-			`	<span class="WA xY ${importantMarkerClass}"></span>` +
-			`	<span class="yX xY label-link .yW">${label}</span>` +
-			`	<span class="xW xY"><span title="${getRawDate(email)}"></span></span>` +
-			"</div>");
+	const bundleWrapper = htmlToElements(`
+			<div class="zA yO" bundleLabel="${label}">
+				<span class="oZ-x3 xY aid bundle-image"><img src="${chrome.runtime.getURL('images/ic_custom-cluster_24px_g60_r3_2x.png')}" /></span>
+				<span class="WA xY ${importantMarkerClass}"></span>
+				<span class="yX xY label-link .yW">${label}</span>
+				<span class="xW xY"><span title="${getRawDate(email)}"></span></span>
+			</div>
+	`);
 
 	addClassToEmail(bundleWrapper, BUNDLE_WRAPPER_CLASS);
 
@@ -272,20 +274,20 @@ const buildBundleWrapper = function(email, label, hasImportantMarkers) {
 	if (email && email.parentNode) email.parentElement.insertBefore(bundleWrapper, email);
 };
 
-const fixLabel = function(label) {
+const fixLabel = function (label) {
 	return encodeURI(label.replace(/ /g, '+'));
 };
 
 function isInInbox() {
-	return document.querySelector(".nZ a[title=Inbox]") != null;
+	return document.querySelector('.nZ a[title=Inbox]') != null;
 }
 
 function checkImportantMarkers() {
-	return document.querySelector("td.WA.xY");
+	return document.querySelector('td.WA.xY');
 }
 
 function getEmails() {
-	const emails = document.querySelectorAll(".BltHke[role=main] .zA");
+	const emails = document.querySelectorAll('.BltHke[role=main] .zA');
 	let myEmailAddress = getMyEmailAddress();
 	let processedEmails = [];
 
@@ -309,7 +311,7 @@ function getEmails() {
 		info.labels = getLabels(email);
 		info.labels.forEach(l => allLabels.add(l));
 
-		info.subjectEl = email.querySelector(".y6");
+		info.subjectEl = email.querySelector('.y6');
 		info.subject = info.subjectEl && info.subjectEl.innerText.trim();
 
 		info.isBundleEmail = () => checkEmailClass(email, BUNDLED_EMAIL_CLASS);
@@ -350,16 +352,16 @@ const updateReminders = function () {
 		const emailEl = emailInfo.emailEl;
 
 		if (emailInfo.isReminder && !emailInfo.reminderAlreadyProcessed()) { // skip if already added class
-			if (emailInfo.subject.toLowerCase() === "reminder") {
-				emailInfo.subjectEl.outerHTML = "";
-				emailEl.querySelectorAll(".Zt").forEach(node => node.outerHTML = "");
-				emailEl.querySelectorAll(".y2").forEach(node => node.style.color = "#202124");
+			if (emailInfo.subject.toLowerCase() === 'reminder') {
+				emailInfo.subjectEl.outerHTML = '';
+				emailEl.querySelectorAll('.Zt').forEach(node => node.outerHTML = '');
+				emailEl.querySelectorAll('.y2').forEach(node => node.style.color = '#202124');
 			}
-			emailEl.querySelectorAll(".yP,.zF").forEach(node => { node.innerHTML = "Reminder";});
+			emailEl.querySelectorAll('.yP,.zF').forEach(node => { node.innerHTML = 'Reminder';});
 
-			const avatarWrapperEl = emailEl.querySelector(".oZ-x3");
+			const avatarWrapperEl = emailEl.querySelector('.oZ-x3');
 			if (avatarWrapperEl && avatarWrapperEl.getElementsByClassName(AVATAR_CLASS).length === 0) {
-				const avatarElement = document.createElement("div");
+				const avatarElement = document.createElement('div');
 				avatarElement.className = AVATAR_CLASS;
 				avatarWrapperEl.appendChild(avatarElement);
 			}
@@ -367,29 +369,29 @@ const updateReminders = function () {
 		} else if (options.showAvatar === 'enabled' && !emailInfo.reminderAlreadyProcessed() && !emailInfo.avatarAlreadyProcessed() && !emailInfo.bundleAlreadyProcessed()) {
 			let participants = Array.from(getEmailParticipants(emailEl));	// convert to array to filter
 			const excludingMe = participants.filter(node =>
-				node.getAttribute("email") !== myEmail &&
-				node.getAttribute("name")
+				node.getAttribute('email') !== myEmail &&
+				node.getAttribute('name')
 			);
 
 			let firstParticipant = participants[0];
 			// If there are others in the participants, use one of their initials instead
 			if (excludingMe.length > 0) firstParticipant = excludingMe[0];
 
-			const name = firstParticipant.getAttribute("name");
-			const firstLetter = (name && name.toUpperCase()[0]) || "-";
-			const targetElement = emailEl.querySelector(".oZ-x3");
+			const name = firstParticipant.getAttribute('name');
+			const firstLetter = (name && name.toUpperCase()[0]) || '-';
+			const targetElement = emailEl.querySelector('.oZ-x3');
 
 			if (targetElement && targetElement.getElementsByClassName(AVATAR_CLASS).length === 0) {
-				const avatarElement = document.createElement("div");
+				const avatarElement = document.createElement('div');
 				avatarElement.className = AVATAR_CLASS;
 				const firstLetterCode = firstLetter.charCodeAt(0);
 				if (firstLetterCode >= 65 && firstLetterCode <= 90) {
-					avatarElement.style.background = "#" + nameColors[firstLetterCode - 65];
+					avatarElement.style.background = '#' + nameColors[firstLetterCode - 65];
 				} else {
-					avatarElement.style.background = "#000000";
+					avatarElement.style.background = '#000000';
 					// Some unicode characters are not affected by 'color: white', hence this alternative
-					avatarElement.style.color = "transparent";
-					avatarElement.style.textShadow = "0 0 0 #ffffff";
+					avatarElement.style.color = 'transparent';
+					avatarElement.style.textShadow = '0 0 0 #ffffff';
 				}
 
 				avatarElement.innerText = firstLetter;
@@ -442,7 +444,7 @@ const updateReminders = function () {
 	}
 };
 
-const getReadStatus = function(emailEl) {
+const getReadStatus = function (emailEl) {
 	return emailEl.className.indexOf('zE') < 0;
 }
 
@@ -451,7 +453,7 @@ const getReadStatus = function(emailEl) {
  * Expects that the curDate should be larger than prevDate, if not, then
  * also return true;
  */
-const isSnoozed = function(email, curDate, prevDate) {
+const isSnoozed = function (email, curDate, prevDate) {
 	const node = email.querySelector('.by1.cL');
 	if (node && node.innerText !== '') return true;
 
@@ -563,13 +565,13 @@ const reorderMenuItems = () => {
       ]);
 
       // Close More menu
-      document.body.querySelector(".J-Ke.n4.ah9").click();
+      document.body.querySelector('.J-Ke.n4.ah9').click();
       observer.disconnect();
     }
 
     if (!loadedMenu && inbox) {
       // Open More menu
-      document.body.querySelector(".J-Ke.n4.ah9").click();
+      document.body.querySelector('.J-Ke.n4.ah9').click();
       loadedMenu = true;
     }
   });
@@ -597,11 +599,8 @@ const init = () => {
 	reorderMenuItems();
 };
 
-if (document.head) {
-  init();
-} else {
-  document.addEventListener("DOMContentLoaded", init);
-}
+if (document.head) init();
+else document.addEventListener('DOMContentLoaded', init);
 
 const queryParentSelector = (elm, sel) => {
   if (!elm) return null;
@@ -619,22 +618,22 @@ const queryParentSelector = (elm, sel) => {
 **
 */
 
-document.addEventListener("DOMContentLoaded", function() {
-	const addReminder = document.createElement("div");
-	addReminder.className = "add-reminder";
-	addReminder.addEventListener("click", function () {
+document.addEventListener('DOMContentLoaded', function () {
+	const addReminder = document.createElement('div');
+	addReminder.className = 'add-reminder';
+	addReminder.addEventListener('click', function () {
 		const myEmail = getMyEmailAddress();
 
-		const composeButton = document.querySelector(".T-I.J-J5-Ji.T-I-KE.L3");
-		triggerMouseEvent(composeButton, "mousedown");
-		triggerMouseEvent(composeButton, "mouseup");
+		const composeButton = document.querySelector('.T-I.J-J5-Ji.T-I-KE.L3');
+		triggerMouseEvent(composeButton, 'mousedown');
+		triggerMouseEvent(composeButton, 'mouseup');
 
-		waitForElement("textarea[name='to']", to => {
-			const title = document.querySelector("input[name='subjectbox']");
-			const body = document.querySelector("div[aria-label='Message Body']");
+		waitForElement('textarea[name="to"]', to => {
+			const title = document.querySelector('input[name="subjectbox"]');
+			const body = document.querySelector('div[aria-label="Message Body"]');
 
 			to.value = myEmail;
-			title.value = "Reminder";
+			title.value = 'Reminder';
 			body.focus();
 		});
 	});

--- a/src/script.js
+++ b/src/script.js
@@ -359,9 +359,8 @@ const updateReminders = function () {
 			);
 
 			let firstParticipant = participants[0];
-			if (excludingMe.length > 0) { // if there are others in the participant, use one of their initials instead
-				firstParticipant = excludingMe[0];
-			}
+			// If there are others in the participants, use one of their initials instead
+			if (excludingMe.length > 0) firstParticipant = excludingMe[0];
 
 			const name = firstParticipant.getAttribute("name");
 			const firstLetter = (name && name.toUpperCase()[0]) || "-";
@@ -408,8 +407,11 @@ const updateReminders = function () {
 		}
 
 		if (options.emailBundling === 'enabled') {
-			// remove labels that no longer have associated emails
-			if (emailInfo.isBundleWrapper() && !allLabels.has(emailEl.getAttribute("bundleLabel"))) {
+			// Hide labels on emails in list
+			document.querySelector('body').setAttribute('emailBundling', true);
+
+			// Remove bundles that no longer have associated emails
+			if (emailInfo.isBundleWrapper() && !allLabels.has(emailEl.getAttribute('bundleLabel'))) {
 				emailEl.remove();
 				continue;
 			}
@@ -425,9 +427,7 @@ const updateReminders = function () {
 				});
 			}
 		}
-
 	}
-
 };
 
 
@@ -437,10 +437,8 @@ const updateReminders = function () {
  * also return true;
  */
 const isSnoozed = function(email, curDate, prevDate) {
-	const node = email.querySelector(".by1.cL");
-	if(node && node.innerText !== "") {
-		return true;
-	}
+	const node = email.querySelector('.by1.cL');
+	if (node && node.innerText !== '') return true;
 
 	return prevDate !== null && curDate < prevDate;
 };

--- a/src/script.js
+++ b/src/script.js
@@ -141,9 +141,8 @@ const cleanupDateLabels = function() {
     	if (row.nextSibling && row.nextSibling.className === 'time-row') row.remove();
 
 			// Check nextSibling recursively until reaching the next .time-row
-			// If all siblings are .bundled-email, then row.remove()
-			// console.log(row, isEmptyDateLabel(row));
-			// if (isEmptyDateLabel(row)) row.remove();
+			// If all siblings are .bundled-email, then hide row
+			if (isEmptyDateLabel(row)) row.hidden = true;
 		});
 };
 

--- a/src/script.js
+++ b/src/script.js
@@ -8,6 +8,7 @@ const emailRegex = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+")
 const REMINDER_EMAIL_CLASS = 'reminder';
 const CALENDAR_EMAIL_CLASS = 'calendar-event';
 const CALENDAR_ATTACHMENT_CLASS = 'calendar-attachment';
+const BUNDLE_PAGE_CLASS = 'bundle-page';
 const BUNDLE_WRAPPER_CLASS = 'bundle-wrapper';
 const UNREAD_BUNDLE_CLASS = 'contains-unread';
 const BUNDLED_EMAIL_CLASS = 'bundled-email';
@@ -319,16 +320,26 @@ const isStarred = email => {
  */
 const checkEmailClass = (emailEl, klass) => emailEl.classList.contains(klass);
 
+const addClassToBody = (klass) => {
+	if (!document.body.classList.contains(klass)) document.body.classList.add(klass);
+};
+
+const removeClassFromBody = (klass) => {
+	if (document.body.classList.contains(klass)) document.body.classList.remove(klass);
+};
+
 const getEmails = () => {
 	const emails = document.querySelectorAll('.BltHke[role=main] .zA');
 	const myEmailAddress = getMyEmailAddress();
 	const isInInboxFlag = isInInbox();
 	const isInBundleFlag = isInBundle();
 	const processedEmails = [];
+	const allLabels = new Set();
 
 	let prevTimeStamp = null;
 	labelStats = {};
-	const allLabels = new Set();
+
+	isInBundleFlag ? addClassToBody(BUNDLE_PAGE_CLASS) : removeClassFromBody(BUNDLE_PAGE_CLASS);
 
 	// Start from last email on page and head towards first
 	for (let i = emails.length - 1; i >= 0; i--) {

--- a/src/script.js
+++ b/src/script.js
@@ -221,11 +221,12 @@ function reloadOptions() {
 		options = ops;
 	});
 
-	// Add option classes to body for css styling
+	// Add option classes to body for css styling, removes avatars when disabled
 	if (options.showAvatar === 'enabled' && !document.body.classList.contains(AVATAR_OPTION_CLASS)) {
 		document.body.classList.add(AVATAR_OPTION_CLASS);
 	} else if (options.showAvatar === 'disabled' && document.body.classList.contains(AVATAR_OPTION_CLASS)) {
 		document.body.classList.remove(AVATAR_OPTION_CLASS);
+		document.querySelectorAll('.' + AVATAR_CLASS).forEach(avatarEl => avatarEl.remove());
 	}
 	
 	// Add option classes to body for css styling, and unbundle emails when disabled
@@ -235,9 +236,9 @@ function reloadOptions() {
 		document.body.classList.remove(BUNDLING_OPTION_CLASS);
 		
 		// Unbundle emails
-		document.querySelectorAll('.' + BUNDLED_EMAIL_CLASS).forEach(x => x.classList.remove(BUNDLED_EMAIL_CLASS));
+		document.querySelectorAll('.' + BUNDLED_EMAIL_CLASS).forEach(emailEl => emailEl.classList.remove(BUNDLED_EMAIL_CLASS));
 		// Remove bundle elements
-		document.querySelectorAll('.' + BUNDLE_WRAPPER_CLASS).forEach(x => x.remove());
+		document.querySelectorAll('.' + BUNDLE_WRAPPER_CLASS).forEach(bundleEl => bundleEl.remove());
 	}
 }
 
@@ -344,7 +345,6 @@ const updateReminders = function () {
 
 	cleanupDateLabels();
 	const emailBundles = getBundledLabels();
-
 
 	for (const emailInfo of emails) {
 		const emailEl = emailInfo.emailEl;

--- a/src/script.js
+++ b/src/script.js
@@ -264,7 +264,7 @@ const addCountToBundle = (label, count) => {
 const addSendersToBundle = (label, senders) => {
 	const bundleSenders = document.querySelector(`div[bundleLabel="${label}"] .bundle-senders`);
 	if (!bundleSenders) return;
-	bundleSenders.innerHTML = `${senders.map(sender => `<span class="${sender.isUnread ? 'strong' : ''}">${sender.name}</span>`).join(', ')}`;
+	bundleSenders.innerHTML = `${senders.reverse().map(sender => `<span class="${sender.isUnread ? 'strong' : ''}">${sender.name}</span>`).join(', ')}`;
 };
 
 const buildBundleWrapper = function (email, label, hasImportantMarkers) {

--- a/src/script.js
+++ b/src/script.js
@@ -66,26 +66,21 @@ const getEmailParticipants = function (email) {
 };
 
 const isReminder = function(email, myEmailAddress) {
-	if(options.reminderTreatment === "none") {
-		return false; // if user doesn't want reminders treated special, then just return as though current email is not a reminder
-	}
+	// if user doesn't want reminders treated special, then just return as though current email is not a reminder
+	if (options.reminderTreatment === "none") return false;
 
 	const nameNodes = getEmailParticipants(email);
 	let allNamesMe = true;
 
-	if(nameNodes.length === 0) {
-		allNamesMe = false;
-	}
+	if (nameNodes.length === 0) allNamesMe = false;
 
 	for (const nameNode of nameNodes) {
-		if (nameNode.getAttribute("email") !== myEmailAddress) {
-			allNamesMe = false;
-		}
+		if (nameNode.getAttribute("email") !== myEmailAddress) allNamesMe = false;
 	}
 
-	if(options.reminderTreatment === "all") {
+	if (options.reminderTreatment === "all") {
 		return allNamesMe;
-	} else if(options.reminderTreatment === "containing-word") {
+	} else if (options.reminderTreatment === "containing-word") {
 		const titleNode = email.querySelector(".y6");
 		return allNamesMe && titleNode && titleNode.innerText.match(/reminder/i);
 	}
@@ -100,9 +95,7 @@ const isCalendarEvent = function(email) {
 
 const addDateLabel = function (email, label) {
 	if (email.previousSibling && email.previousSibling.className === "time-row") {
-		if(email.previousSibling.innerText === label) {
-			return;
-		}
+		if (email.previousSibling.innerText === label) return;
 		email.previousSibling.remove();
 	}
 
@@ -118,33 +111,26 @@ const addDateLabel = function (email, label) {
 
 const getRawDate = function(email) {
 	const dateElement = email.querySelector(".xW.xY span");
-	if(dateElement) {
-		return dateElement.getAttribute("title");
-	}
+	if (dateElement) return dateElement.getAttribute("title");
 };
 
 const getDate = function(rawDate) {
-    if(rawDate) {
-		return new Date(rawDate);
-	}
+	if (rawDate) return new Date(rawDate);
 };
 
 const buildDateLabel = function(date) {
 	let now = new Date();
+	if (date === undefined) return;
 
-	if(date === undefined) {
-		return;
-	}
-
-	if(now.getFullYear() == date.getFullYear()) {
-		if(now.getMonth() == date.getMonth()) {
-			if(now.getDate() == date.getDate()) { return DateLabels.Today; }
-			if(now.getDate()-1 == date.getDate()) { return DateLabels.Yesterday; }
+	if (now.getFullYear() == date.getFullYear()) {
+		if (now.getMonth() == date.getMonth()) {
+			if (now.getDate() == date.getDate()) return DateLabels.Today;
+			if (now.getDate()-1 == date.getDate()) return DateLabels.Yesterday;
 			return DateLabels.ThisMonth;
 		}
 		return months[date.getMonth()];
 	}
-	if(now.getFullYear()-1 == date.getFullYear()) { return DateLabels.LastYear; }
+	if (now.getFullYear()-1 == date.getFullYear()) return DateLabels.LastYear;
 
 	return date.getFullYear().toString();
 };
@@ -154,16 +140,17 @@ const cleanupDateLabels = function() {
     	// Delete any back to back date labels
     	if (row.nextSibling && row.nextSibling.className === 'time-row') row.remove();
 
-			// TODO: check nextSibling recursively until reaching the next .time-row
-			// if all siblings are .bundled-email, then row.remove()
-			if (isEmptyDateLabel(row)) row.remove();
+			// Check nextSibling recursively until reaching the next .time-row
+			// If all siblings are .bundled-email, then row.remove()
+			// console.log(row, isEmptyDateLabel(row));
+			// if (isEmptyDateLabel(row)) row.remove();
 		});
 };
 
 const isEmptyDateLabel = function (row) {
 	const sibling = row.nextSibling;
 	if (sibling.className === 'time-row') return true;
-	else if (sibling.classList.contains('.bundled-email')) return false;
+	else if (![...sibling.classList].includes('bundled-email')) return false;
 	return isEmptyDateLabel(sibling);
 }
 
@@ -172,12 +159,12 @@ const getBundledLabels = function() {
 };
 
 const addEventAttachment = function(email) {
-	if(email.querySelector("." + CALENDAR_ATTACHMENT_CLASS)) return;
+	if (email.querySelector("." + CALENDAR_ATTACHMENT_CLASS)) return;
 
 	let title = "Calendar Event";
 	let time = "";
 	const titleNode = email.querySelector(".bqe,.bog");
-	if(titleNode) {
+	if (titleNode) {
 		const titleFullText = titleNode.innerText;
 		let matches = Array.from(titleFullText.matchAll(/[^:]*: ([^@]*)@(.*)/g))[0];
 		if (matches) {
@@ -186,7 +173,7 @@ const addEventAttachment = function(email) {
 		}
 	}
 
-	//build calendar attachment, this is based on regular attachments we no longer
+	// build calendar attachment, this is based on regular attachments we no longer
 	// have access to inbox to see the full structure
 	const span = document.createElement("span");
 	span.appendChild(document.createTextNode("Attachment"));
@@ -205,11 +192,9 @@ const addEventAttachment = function(email) {
 	attachmentContentWrapper.appendChild(attachmentNameSpan);
 	attachmentContentWrapper.appendChild(attachmentTimeSpan);
 
-	//find Invitation Action
+	// find Invitation Action
 	const action = email.querySelector(".aKS");
-	if(action) {
-		attachmentContentWrapper.appendChild(action);
-	}
+	if (action) attachmentContentWrapper.appendChild(action);
 
 	const imageSpan = document.createElement("span");
 	imageSpan.classList.add("calendar-image");
@@ -227,9 +212,7 @@ const addEventAttachment = function(email) {
 	attachmentNode.appendChild(attachmentCard);
 
 	const emailSubjectWrapper = email.querySelectorAll(".a4W");
-	if(emailSubjectWrapper) {
-		emailSubjectWrapper[0].appendChild(attachmentNode);
-	}
+	if (emailSubjectWrapper) emailSubjectWrapper[0].appendChild(attachmentNode);
 };
 
 function reloadOptions() {
@@ -273,9 +256,7 @@ const buildBundleWrapper = function(email, label, hasImportantMarkers) {
 		location.href = `#search/in%3Ainbox+label%3A"${fixLabel(label.toLowerCase())}"`;
 	};
 
-	if(email && email.parentNode) {
-		email.parentElement.insertBefore(bundleWrapper, email);
-	}
+	if (email && email.parentNode) email.parentElement.insertBefore(bundleWrapper, email);
 };
 
 const fixLabel = function(label) {
@@ -300,7 +281,7 @@ function getEmails() {
 	let labelStats = {};
 
 	// start from end and go to beginning.
-	for(let i=emails.length - 1; i >= 0; i--) {
+	for (let i = emails.length - 1; i >= 0; i--) {
 		let email = emails[i];
 		let info = {};
 		info.emailEl = email;
@@ -310,7 +291,7 @@ function getEmails() {
 		info.date = getDate(info.dateString);
 		info.dateLabel = buildDateLabel(info.date);
 		info.isSnooze = isSnoozed(email, info.date, prevTimeStamp);
-		if(!info.isSnooze && info.date) prevTimeStamp = info.date; // only update prevTimeStamp if not snoozed, because we might have multiple snoozes back to back.
+		if (!info.isSnooze && info.date) prevTimeStamp = info.date; // only update prevTimeStamp if not snoozed, because we might have multiple snoozes back to back.
 		info.isCalendarEvent = isCalendarEvent(email);
 		info.labels = getLabels(email);
 		info.labels.forEach(l => allLabels.add(l));
@@ -407,7 +388,7 @@ const updateReminders = function () {
 			addClassToEmail(emailEl, AVATAR_EMAIL_CLASS);
 		}
 
-		if(emailInfo.isCalendarEvent && !emailInfo.calendarAlreadyProcessed()) {
+		if (emailInfo.isCalendarEvent && !emailInfo.calendarAlreadyProcessed()) {
 			addClassToEmail(emailEl, CALENDAR_EMAIL_CLASS);
 			addEventAttachment(emailEl);
 		}
@@ -417,7 +398,7 @@ const updateReminders = function () {
 		// This is a hack for snoozed emails. If the snoozed email is the
 		// first email, we just assume it arrived 'Today', any other snoozed email
 		// joins whichever label the previous email had.
-		if(emailInfo.isSnooze) {
+		if (emailInfo.isSnooze) {
 			label = (lastLabel == null) ? DateLabels.Today : lastLabel;
 		}
 
@@ -427,9 +408,9 @@ const updateReminders = function () {
 			lastLabel = label;
 		}
 
-		if(options.emailBundling === 'enabled') {
+		if (options.emailBundling === 'enabled') {
 			// remove labels that no longer have associated emails
-			if(emailInfo.isBundleWrapper() && !allLabels.has(emailEl.getAttribute("bundleLabel"))) {
+			if (emailInfo.isBundleWrapper() && !allLabels.has(emailEl.getAttribute("bundleLabel"))) {
 				emailEl.remove();
 				continue;
 			}
@@ -574,9 +555,7 @@ const reorderMenuItems = () => {
       observer.disconnect();
     }
 
-    if (
-      !loadedMenu && inbox
-    ) {
+    if (!loadedMenu && inbox) {
       // Open More menu
       document.body.querySelector(".J-Ke.n4.ah9").click();
       loadedMenu = true;
@@ -613,15 +592,11 @@ if (document.head) {
 }
 
 const queryParentSelector = (elm, sel) => {
-  if (!elm) {
-    return null;
-  }
+  if (!elm) return null;
   var parent = elm.parentElement;
   while (!parent.matches(sel)) {
     parent = parent.parentElement;
-    if (!parent) {
-      return null;
-    }
+    if (!parent) return null;
   }
   return parent;
 };
@@ -632,10 +607,10 @@ const queryParentSelector = (elm, sel) => {
 **
 */
 
-document.addEventListener("DOMContentLoaded", function(event) {
+document.addEventListener("DOMContentLoaded", function() {
 	const addReminder = document.createElement("div");
 	addReminder.className = "add-reminder";
-	addReminder.addEventListener("click", function (e) {
+	addReminder.addEventListener("click", function () {
 		const myEmail = getMyEmailAddress();
 
 		const composeButton = document.querySelector(".T-I.J-J5-Ji.T-I-KE.L3");

--- a/src/script.js
+++ b/src/script.js
@@ -313,7 +313,7 @@ function getEmails() {
 		if ((isInInboxFlag || isInBundleFlag) && info.isUnbundled && !info.unbundledAlreadyProcessed()) {
 			addClassToEmail(email, UNBUNDLED_EMAIL_CLASS);
 			info.emailEl.querySelectorAll('.ar.as').forEach(labelEl => {
-				if (labelEl.innerText.indexOf(UNBUNDLED_PARENT_LABEL) >= 0) {
+				if (labelEl.querySelector('.at').title.indexOf(UNBUNDLED_PARENT_LABEL) >= 0) {
 					// Remove 'Unbundled/' from display in the UI
 					labelEl.querySelector('.av').innerText = labelEl.innerText.replace(UNBUNDLED_PARENT_LABEL + '/', '');
 				} else {

--- a/src/script.js
+++ b/src/script.js
@@ -259,7 +259,7 @@ const buildBundleWrapper = function(email, label, hasImportantMarkers) {
 };
 
 const fixLabel = function(label) {
-	return encodeURI(label.replace(/[^a-zA-Z]/, "-"));
+	return encodeURI(label.replace(/ /g, '+'));
 };
 
 function isInInbox() {

--- a/src/style.css
+++ b/src/style.css
@@ -1233,6 +1233,6 @@ div[aria-label="Hangouts"][role="complementary"] {
 
 /* Hide labels on emails when bundling is enabled */
 body.email-bundling-enabled .bundled-email .yi,
-body.email-bundling-enabled .nH.ar4.B .yi {
+body.email-bundling-enabled.bundle-page .nH.ar4.B .yi {
 	display: none !important;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -1213,9 +1213,20 @@ div[aria-label="Hangouts"][role="complementary"] {
 .bundle-wrapper .label-link {
 	margin-left: 5px;
 	font-size: 13px;
+	margin-right: 32px;
 }
-.bundle-wrapper.contains-unread .label-link {
+.bundle-wrapper.contains-unread .label-link,
+.bundle-wrapper .bundle-senders span.strong {
 	font-weight: 700;
+}
+.bundle-senders {
+	color: #202124 !important;
+}
+
+.bundle-wrapper .label-link .bundle-count {
+	font-weight: 400;
+	margin-left: 5px;
+	color: gray;
 }
 
 .bundled-email {

--- a/src/style.css
+++ b/src/style.css
@@ -498,7 +498,6 @@ td.apU.xY .T-KT.xf::before {
 	background-repeat: repeat-x;
 	padding: 12px;
 	width: 48px;
-	length: 48px;
 	border: 3px solid #F2F2F2;
   	box-sizing: border-box;
 	border-radius: 30%;

--- a/src/style.css
+++ b/src/style.css
@@ -1223,11 +1223,16 @@ div[aria-label="Hangouts"][role="complementary"] {
 	display: none !important;
 }
 
-/* bundle row settings */
+/* Bundle row settings */
 .zA > span.oZ-x3 {
 	order: 0;
 }
 
 .hide-important-markers {
+	display: none !important;
+}
+
+/* Hide labels on emails when bundling is enabled */
+body[emailBundling="true"] .yi {
 	display: none !important;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -1233,6 +1233,6 @@ div[aria-label="Hangouts"][role="complementary"] {
 }
 
 /* Hide labels on emails when bundling is enabled */
-body[emailBundling="true"] .yi {
+body.email-bundling-enabled .yi {
 	display: none !important;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -1114,7 +1114,7 @@ header form input {
 	border-radius: 50%;
 	font-size: 18px;
 	font-family: 'Roboto', sans-serif;
-	font-weight: 500;
+	font-weight: 400;
 	position: relative;
 	left: -6px;
 	flex: 32px 0 0;

--- a/src/style.css
+++ b/src/style.css
@@ -1219,8 +1219,14 @@ div[aria-label="Hangouts"][role="complementary"] {
 .bundle-wrapper .bundle-senders span.strong {
 	font-weight: 700;
 }
+
 .bundle-senders {
 	color: #202124 !important;
+}
+/* Parent of .bundle-senders */
+.label-link + .xW.xY {
+	flex-grow: 1;
+	overflow: hidden;
 }
 
 .bundle-wrapper .label-link .bundle-count {

--- a/src/style.css
+++ b/src/style.css
@@ -1232,6 +1232,7 @@ div[aria-label="Hangouts"][role="complementary"] {
 }
 
 /* Hide labels on emails when bundling is enabled */
-body.email-bundling-enabled .yi {
+body.email-bundling-enabled .bundled-email .yi,
+body.email-bundling-enabled .nH.ar4.B .yi {
 	display: none !important;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -1213,6 +1213,9 @@ div[aria-label="Hangouts"][role="complementary"] {
 
 .bundle-wrapper .label-link {
 	margin-left: 5px;
+	font-size: 13px;
+}
+.bundle-wrapper .label-link .contains-unread {
 	font-weight: 700;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -1214,7 +1214,7 @@ div[aria-label="Hangouts"][role="complementary"] {
 	margin-left: 5px;
 	font-size: 13px;
 }
-.bundle-wrapper .label-link .contains-unread {
+.bundle-wrapper.contains-unread .label-link {
 	font-weight: 700;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -1214,7 +1214,6 @@ div[aria-label="Hangouts"][role="complementary"] {
 .bundle-wrapper .label-link {
 	margin-left: 5px;
 	font-weight: 700;
-	font-size: 13px;
 }
 
 .bundled-email {


### PR DESCRIPTION
Copy/paste from https://github.com/boukestam/inbox-in-gmail/pull/68#issuecomment-488645014

## Changes

- Hide date/time headers if they have no visible emails beneath (because all have class bundled-email)
- URL encoding bug reported by @jcgoble3 when label contains a period, like "TheForce.net"
- URL encoding bug when label contains a space. Replaces with `+` instead of `%20`, because Gmail would add an additional redirect to your history making it very hard to use the back button to get back to the Inbox
- Hide label on emails when bundling is enabled (reported by @jcgoble3)
- Found a bug, labels get cut off after 23 characters with an ellipses `...`
- Unbundle emails, remove bundle links when bundling disabled in `reloadOptions()`
- Remove avatars when avatars are disabled in `reloadOptions()`
- Made code style more consistent, according to Airbnb JavaScript Style Guide: single quotes, spacing between `function` and `()`, etc.
- Do not bundle emails with parent label `Unbundled` (to resolve request from @jcgoble3). Strip `Unbundled/` from displayed label on email. Also, set a class on this email that prevents the label from being hidden when bundling is active.
- Related to `Unbundled` parent label:
  - need to hide labels inside bundle, but not in normal search
  - in Inbox, hide display of non-Unbundle-parented labels
- Pinned/Starred emails display outside of bundles (I think that's how it worked in Inbox, at least?). This updates dynamically, too, although it might take a second.
- Bold bundle label-link only when containing unread emails
- Show message count on bundle label like Inbox, ex: `Promotions (15)`
- Display list of senders on bundle, where Subject field usually goes in a normal email row. Also, correct me if I'm wrong, but I think each unread sender was shown as bold in Inbox.

## Maybe/Future TODO

These are most likely not to be done in this PR. This is just an up to date list of the delta between the real Inbox and this extension, because the thread for PR #68 was getting huge and hard to track:

- Display the original Inbox icons and text color for the default categories, as shown in [this screenshot](https://user-images.githubusercontent.com/5100126/56964667-905d4500-6b53-11e9-8112-911afb594e3a.png). For custom labels, if possible, use their label color for the text color and icon. To complete this, we'd first need to get a link to those icon images... maybe @jcgoble3 could help with that.

The functionality listed below would likely require [Gmail.js](https://github.com/KartikTalwar/gmail.js):
- Display a sweep all emails icon button on bundle row on mouse hover, clicking this would archive all emails contained in bundle that aren't pinned
- Display a back button inside the bundle (search page), to return to the inbox
- Clicking done on an open bundled email should return you to the bundle (search page)
- If inside an empty bundle (search page), it should return you to the inbox (including if you clicked Done on an email in the list)